### PR TITLE
Fix the parsing logic of audio clip

### DIFF
--- a/Sources/parser/EpubParser.swift
+++ b/Sources/parser/EpubParser.swift
@@ -292,9 +292,11 @@ final public class EpubParser {
             if let textRef = body.attributes["epub:textref"] { // Prevent the crash on the japanese book
                 node.text = normalize(base: mediaOverlayLink.href!, href: textRef)
             }
-            // get body parameters <par>
-            SMILParser.parseParameters(in: body, withParent: node, base: mediaOverlayLink.href)
-            SMILParser.parseSequences(in: body, withParent: node, publicationSpine: &publication.spine, base: mediaOverlayLink.href)
+            // get body parameters <par>a
+            if let href = mediaOverlayLink.href {
+                SMILParser.parseParameters(in: body, withParent: node, base: href)
+                SMILParser.parseSequences(in: body, withParent: node, publicationSpine: &publication.spine, base: href)
+            }
             // "/??/xhtml/mo-002.xhtml#mo-1" => "/??/xhtml/mo-002.xhtml"
             guard let baseHref = node.text?.components(separatedBy: "#")[0],
                 let link = publication.spine.first(where: {


### PR DESCRIPTION
Closes readium/r2-testapp-swift#4 

Fixes this crash issue triggered by nil value. Improve the parsing logic for audio clip inside SMIL file.
This PR relays on another [PR](https://github.com/readium/r2-shared-swift/pull/4)

In the old code, it will ignore any audio element which doesn't have both clipBegin and clipEnd. That's logically wrong. This PR changed it to correct logic, it also fixed the nil value crash as well. 