### PR TITLE
Enable Travis CI on develop and master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: swift
+osx_image: xcode9.3
+
+branches:
+  only:
+    - master
+    - develop
+
+cache:
+  directories:
+    - Carthage
+
+before_install:
+  - brew update
+  - brew outdated carthage || brew upgrade carthage
+  - carthage bootstrap --verbose --no-use-binaries --platform iOS --cache-builds
+
+script:
+  - xcodebuild clean build -project r2-streamer-swift.xcodeproj -scheme r2-streamer-swift -destination "platform=iOS Simulator,name=iPhone 8,OS=11.3" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO -quiet


### PR DESCRIPTION
This PR enables Travis on `develop` and `master` branches. For now, it will only trigger a `build` action on a commit and a pull request event.