### PR TITLE
Quick fix for #63 duplicated TOC of LCP book

### DIFF
--- a/Sources/parser/EpubParser.swift
+++ b/Sources/parser/EpubParser.swift
@@ -220,7 +220,8 @@ final public class EpubParser {
         let newPageListItems = NavigationDocumentParser.pageList(fromNavigationDocument: navDocument,
                                                                  locatedAt: navigationDocumentPath)
 
-        publication.tableOfContents.append(contentsOf:  newTableOfContentsItems)
+        //publication.tableOfContents.append(contentsOf:  newTableOfContentsItems)
+        publication.tableOfContents = newTableOfContentsItems
         publication.landmarks.append(contentsOf: newLandmarksItems)
         publication.listOfAudioFiles.append(contentsOf: newListOfAudiofiles)
         publication.listOfIllustrations.append(contentsOf: newListOfIllustrations)


### PR DESCRIPTION
This is a quick fix for duplicated TOC content when loading LCP book.

The reason is clean. It's appending TOC content each time when loading then book.
While, it has the same appending logic for all the other properties. That's looks quite strange.

Need more research later for potential risk. 