### PR TITLE
Use ES5 code for iOS9

### DIFF
--- a/R2Streamer/ReadiumCSS-after.css
+++ b/R2Streamer/ReadiumCSS-after.css
@@ -903,4 +903,3 @@ body {
 :root[style*="readium-advanced-on"][style*="--USER__typeScale"] h3 {
   font-size: calc(1rem * var(--USER__typeScale)) !important;
 }
-/*# sourceMappingURL=ReadiumCSS-after.css.map */

--- a/R2Streamer/ReadiumCSS-before.css
+++ b/R2Streamer/ReadiumCSS-before.css
@@ -603,4 +603,3 @@ table {
   overflow-x: auto;
   box-sizing: var(--RS__boxSizingTable);
 }
-/*# sourceMappingURL=ReadiumCSS-before.css.map */

--- a/R2Streamer/ReadiumCSS-default.css
+++ b/R2Streamer/ReadiumCSS-default.css
@@ -160,4 +160,3 @@ th, td {
   padding: 4px;
   border: 1px solid currentColor;
 }
-/*# sourceMappingURL=ReadiumCSS-default.css.map */

--- a/R2Streamer/utils-old.js
+++ b/R2Streamer/utils-old.js
@@ -1,0 +1,95 @@
+// Notify native code that the page has loaded.
+window.addEventListener("load", function(){ // on page load
+                        // Notify native code that the page is loaded.
+                        webkit.messageHandlers.didLoad.postMessage("");
+                        }, false);
+
+var last_known_scroll_position = 0;
+var ticking = false;
+
+// Position in range [0 - 1].
+var update = function(position) {
+    var positionString = position.toString()
+    webkit.messageHandlers.updateProgression.postMessage(positionString);
+};
+
+window.addEventListener('scroll', function(e) {
+                       last_known_scroll_position = window.scrollX / document.getElementsByTagName("body")[0].scrollWidth;
+                       if (!ticking) {
+                       window.requestAnimationFrame(function() {
+                                                    update(last_known_scroll_position);
+                                                    ticking = false;
+                                                    });
+                       }
+                       ticking = true;
+                       });
+
+// Scroll to the given TagId in document and snap.
+var scrollToId = function(id) {
+    var element = document.getElementById(id);
+    var elementOffset = element.scrollLeft // element.getBoundingClientRect().left works for Gutenbergs books
+    var offset = window.scrollX + elementOffset;
+
+    document.body.scrollLeft = snapOffset(offset);
+};
+
+// Position must be in the range [0 - 1], 0-100%.
+var scrollToPosition = function(position) {
+    console.log("ScrollToPosition");
+    if ((position < 0) || (position > 1)) {
+        console.log("InvalidPosition");
+        return;
+    }
+    var offset = document.getElementsByTagName("body")[0].scrollWidth * position;
+
+    console.log("ScrollToOffset", offset);
+    document.body.scrollLeft = snapOffset(offset);
+};
+
+var scrollLeft = function() {
+    var offset = window.scrollX - maxScreenX;
+
+    if (offset >= 0) {
+        document.body.scrollLeft = offset;
+        return 0;
+    } else {
+        document.body.scrollLeft = 0;
+        return "edge"; // Need to previousDocument.
+    }
+};
+
+var scrollRight = function() {
+    var offset = window.scrollX + maxScreenX;
+    var scrollWidth = document.getElementsByTagName("body")[0].scrollWidth;
+
+    if (offset < scrollWidth) {
+        document.body.scrollLeft = offset;
+        return 0;
+    } else {
+        document.body.scrollLeft = scrollWidth;
+        return "edge"; // Need to nextDocument.
+    }
+};
+
+// Snap the offset to the screen width (page width).
+var snapOffset = function(offset) {
+    var value = offset + 1;
+
+    return value - (value % maxScreenX);
+};
+
+/// User Settings.
+
+// For setting user setting.
+var setProperty = function(key, value) {
+    var root = document.documentElement;
+
+    root.style.setProperty(key, value);
+};
+
+// For removing user setting.
+var removeProperty = function(key) {
+    var root = document.documentElement;
+
+    root.style.removeProperty(key);
+};

--- a/Sources/fetcher/ContentFilter.swift
+++ b/Sources/fetcher/ContentFilter.swift
@@ -47,6 +47,15 @@ internal extension ContentFilters {
 ///     - Font deobfuscation using the Decoder object.
 ///     - HTML injections (scripts css/js).
 final internal class ContentFiltersEpub: ContentFilters {
+    // File name for untils.js, using ES5 code for any version older than iOS 10.
+    internal let utilsJS:String = {
+        if #available(iOS 10, *) {
+            return "utils.js"
+        } else {
+            return "utils-old.js"
+        }
+    } ()
+    
     /// Apply the Epub content filters on the content of the `input` stream para-
     /// meter.
     ///
@@ -165,7 +174,8 @@ final internal class ContentFiltersEpub: ContentFilters {
         }
         let cssAfter = getHtmlLink(forResource: "\(baseUrl)styles/ReadiumCSS-after.css")
         let scriptTouchHandling = getHtmlScript(forResource: "\(baseUrl)scripts/touchHandling.js")
-        let scriptUtils = getHtmlScript(forResource: "\(baseUrl)scripts/utils.js")
+        
+        let scriptUtils = getHtmlScript(forResource: "\(baseUrl)scripts/\(utilsJS)")
 
         resourceHtml = resourceHtml.insert(string: cssAfter, at: headEnd)
         resourceHtml = resourceHtml.insert(string: scriptTouchHandling, at: headEnd)

--- a/Sources/fetcher/ContentFilter.swift
+++ b/Sources/fetcher/ContentFilter.swift
@@ -212,7 +212,7 @@ final internal class ContentFiltersEpub: ContentFilters {
         // Touch event bubbling.
         includes.append(getHtmlScript(forResource: "\(baseUrl)scripts/touchHandling.js"))
         // Misc JS utils.
-        includes.append(getHtmlScript(forResource: "\(baseUrl)scripts/utils.js"))
+        includes.append(getHtmlScript(forResource: "\(baseUrl)scripts/\(utilsJS)"))
 
         for element in includes {
             resourceHtml = resourceHtml.insert(string: element, at: endHeadIndex)

--- a/r2-streamer-swift.xcodeproj/project.pbxproj
+++ b/r2-streamer-swift.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		03D011F0208020270097A87C /* Minizip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03D011EF208020270097A87C /* Minizip.framework */; };
+		570754AA2088EE31008A9013 /* utils-old.js in Resources */ = {isa = PBXBuildFile; fileRef = 570754A92088EE31008A9013 /* utils-old.js */; };
 		59501DD71E2FB0D700D1B4BF /* R2Streamer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 59501DCD1E2FB0D700D1B4BF /* R2Streamer.framework */; };
 		59501DDE1E2FB0D700D1B4BF /* R2Streamer.h in Headers */ = {isa = PBXBuildFile; fileRef = 59501DD01E2FB0D700D1B4BF /* R2Streamer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		59501E031E2FB16600D1B4BF /* Fetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59501DE81E2FB16600D1B4BF /* Fetcher.swift */; };
@@ -99,6 +100,7 @@
 
 /* Begin PBXFileReference section */
 		03D011EF208020270097A87C /* Minizip.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Minizip.framework; path = Carthage/Build/iOS/Minizip.framework; sourceTree = "<group>"; };
+		570754A92088EE31008A9013 /* utils-old.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = "utils-old.js"; sourceTree = "<group>"; };
 		59501DCD1E2FB0D700D1B4BF /* R2Streamer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = R2Streamer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		59501DD01E2FB0D700D1B4BF /* R2Streamer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = R2Streamer.h; sourceTree = "<group>"; };
 		59501DD11E2FB0D700D1B4BF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -316,6 +318,7 @@
 				F36D24D61F546FEA00A00BF1 /* ReadiumCSS-before.css */,
 				F36D24D71F546FEA00A00BF1 /* ReadiumCSS-default.css */,
 				F3DCEB241F1CA92300061978 /* touchHandling.js */,
+				570754A92088EE31008A9013 /* utils-old.js */,
 				F3D462F51F28D56C00505E59 /* utils.js */,
 			);
 			name = Resources;
@@ -468,6 +471,7 @@
 				F36D24D81F546FEA00A00BF1 /* ReadiumCSS-after.css in Resources */,
 				F3DCEB251F1CA92300061978 /* touchHandling.js in Resources */,
 				F36D24DA1F546FEA00A00BF1 /* ReadiumCSS-default.css in Resources */,
+				570754AA2088EE31008A9013 /* utils-old.js in Resources */,
 				F3D462F61F28D56C00505E59 /* utils.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
iOS 9 doesn't support some ES6 features, so we got this bug. Settings menu doesn't work.
https://github.com/readium/r2-testapp-swift/issues/47

This PR fixed issue by creating separated JS file for ES5, then it for iOS 9. 
