### PR TITLE
Ignore input element for touch handling

### DIFF
--- a/R2Streamer/touchHandling.js
+++ b/R2Streamer/touchHandling.js
@@ -54,6 +54,8 @@ var handleTouchEnd = function(event) {
     if(!singleTouchGesture) {
         return;
     }
+    //https://stackoverflow.com/questions/4878484/difference-between-tagname-and-nodename
+    if (event.target.nodeName == "input") {return}
 
     var touch = event.changedTouches[0];
 


### PR DESCRIPTION
All the Input nodes should be ignored under custom touch handling. Otherwise there will be endless trouble. This PR ignored all the Input nodes, so Webkit could handle them in the proper way.

Fix issue https://github.com/readium/r2-testapp-swift/issues/8