### PR TITLE
Expose updated date and use it for sorting

### DIFF
--- a/Sources/model/Container.swift
+++ b/Sources/model/Container.swift
@@ -46,6 +46,9 @@ public enum ContainerError: Error {
 
 /// Provide methods for accessing raw data from container's files.
 public protocol Container {
+    
+    /// A dictionary object that describes the attributes (file, directory, symlink, and so on) of the file specified by the path of this Container. The keys in the dictionary are described in File Attribute Keys.
+    var attribute: [FileAttributeKey : Any]? {get set}
 
     /// See `RootFile`.
     var rootFile: RootFile { get set }

--- a/Sources/model/ContainerCbz.swift
+++ b/Sources/model/ContainerCbz.swift
@@ -12,6 +12,8 @@ extension ContainerCbz: Loggable {}
 
 /// Container for archived CBZ publications.
 public class ContainerCbz: CbzContainer, ZipArchiveContainer {
+    public var attribute: [FileAttributeKey : Any]?
+    
     /// See `RootFile`.
     public var rootFile: RootFile
     /// The zip archive object containing the Epub.

--- a/Sources/model/ContainerCbzDirectory.swift
+++ b/Sources/model/ContainerCbzDirectory.swift
@@ -12,6 +12,8 @@ extension ContainerCbzDirectory: Loggable {}
 
 /// Container for expanded CBZ publications.
 public class ContainerCbzDirectory: CbzContainer, DirectoryContainer {
+    public var attribute: [FileAttributeKey : Any]?
+    
     /// See `RootFile`.
     public var rootFile: RootFile
     public var drm: Drm?

--- a/Sources/model/ContainerEpub.swift
+++ b/Sources/model/ContainerEpub.swift
@@ -12,6 +12,8 @@ extension ContainerEpub: Loggable {}
 
 /// Container for EPUB publications. (Archived)
 public class ContainerEpub: ZipArchiveContainer {
+    public var attribute: [FileAttributeKey : Any]?
+    
     /// See `RootFile`.
     public var rootFile: RootFile
     /// The zip archive object containing the Epub.

--- a/Sources/model/ContainerEpubDirectory.swift
+++ b/Sources/model/ContainerEpubDirectory.swift
@@ -12,6 +12,8 @@ extension ContainerEpubDirectory: Loggable {}
 
 /// Container for expended EPUB publications. (Directory)
 public class ContainerEpubDirectory: DirectoryContainer {
+    public var attribute: [FileAttributeKey : Any]?
+    
     /// See `RootFile`.
     public var rootFile: RootFile
     public var drm: Drm?    

--- a/Sources/parser/CbzParser.swift
+++ b/Sources/parser/CbzParser.swift
@@ -41,6 +41,10 @@ public class CbzParser {
         // Generate the `Container` for `fileAtPath`.
         let container: CbzContainer = try generateContainerFrom(fileAtPath: path)
         let publication = Publication()
+        
+        if let updatedDate = container.attribute?[FileAttributeKey.modificationDate] as? Date {
+            publication.updatedDate = updatedDate
+        }
 
         publication.metadata.multilangTitle = title(from: path)
         publication.metadata.identifier = path
@@ -100,6 +104,9 @@ public class CbzParser {
         } else {
             container = ContainerCbz(path: path)
         }
+        
+        container?.attribute = try? FileManager.default.attributesOfItem(atPath: path)
+        
         guard let containerUnwrapped = container else {
             throw CbzParserError.missingFile(path: path)
         }

--- a/Sources/parser/EpubParser.swift
+++ b/Sources/parser/EpubParser.swift
@@ -103,6 +103,11 @@ final public class EpubParser {
         var publication = try OPFParser.parseOPF(from: document,
                                                  with: container.rootFile.rootFilePath,
                                                  and: epubVersion)
+        
+        if let updatedDate = container.attribute?[FileAttributeKey.modificationDate] as? Date {
+            publication.updatedDate = updatedDate
+        }
+ 
         // Check if the publication is DRM protected.
         let drm = scanForDrm(in: container)
         // Parse the META-INF/Encryption.xml.
@@ -391,6 +396,9 @@ final public class EpubParser {
         } else {
             container = ContainerEpub(path: path)
         }
+        
+        container?.attribute = try? FileManager.default.attributesOfItem(atPath: path)
+        
         guard let containerUnwrapped = container else {
             throw EpubParserError.missingFile(path: path)
         }

--- a/Sources/server/PublicationServer.swift
+++ b/Sources/server/PublicationServer.swift
@@ -48,7 +48,7 @@ public class PublicationServer {
         get {
             let publications = pubBoxes.values.compactMap({ $0.publication })
 
-            return publications.sorted(by: { $0.metadata.title < $1.metadata.title })
+            return publications.sorted(by: {$0.updatedDate > $1.updatedDate})
         }
     }
 


### PR DESCRIPTION
As discussed, the app will use last updated date descending as sorting order.
This PR is not using SQLite, the updated date came from iOS file system directly.
SQLite version will come later with good duplication check for different kinds of books.