### PR TITLE
Fix layout and scrolling issues for FXL publications

### DIFF
--- a/R2Streamer/scripts/touchHandling.js
+++ b/R2Streamer/scripts/touchHandling.js
@@ -63,11 +63,7 @@ var handleTouchEnd = function(event) {
     var relativeDistanceY = Math.abs(((touch.screenY % maxScreenY) - startY) / maxScreenY);
     var touchDistance = Math.max(relativeDistanceX, relativeDistanceY);
 
-    var scrollWidth = document.scrollWidth;
-    var screenWidth = maxScreenX;
-    var tapAreaWidth = maxScreenX * 0.2;
-
-    // // Tap to turn.
+    // Tap to turn.
     if(touchDistance < 0.01) {
         var position = Math.abs(touch.clientX % maxScreenX) / maxScreenX;
         if (position <= 0.2) {

--- a/R2Streamer/scripts/touchHandling.js
+++ b/R2Streamer/scripts/touchHandling.js
@@ -65,7 +65,17 @@ var handleTouchEnd = function(event) {
 
     // Tap to turn.
     if(touchDistance < 0.01) {
-        var position = Math.abs(touch.clientX % maxScreenX) / maxScreenX;
+        //var position = Math.abs(touch.clientX % maxScreenX) / maxScreenX;
+        var position;
+        
+        if (maxScreenX == window.innerWidth) {
+            // No scroll and default zoom
+            position = touch.clientX / document.body.clientWidth
+        } else {
+            // FXL
+            position = touch.screenX / document.body.clientWidth
+        }
+        
         if (position <= 0.2) {
             // TAP left.
             console.log("LeftTapped");

--- a/R2Streamer/scripts/utils-old.js
+++ b/R2Streamer/scripts/utils-old.js
@@ -52,43 +52,57 @@ var scrollToPosition = function(position, dir) {
 
 var scrollLeft = function(dir) {
     var scrollWidth = document.body.scrollWidth;
-    var newOffset = window.scrollX - maxScreenX;
-    var edge = -scrollWidth + maxScreenX;
+    var newOffset = window.scrollX - window.innerWidth;
+    var edge = -scrollWidth + window.innerWidth;
     var newEdge = (dir == "rtl")? edge:0;
     
-    if (newOffset > newEdge) {
-        document.body.scrollLeft = newOffset
-        return 0;
+    if (window.innerWidth == scrollWidth) {
+        // No scroll and default zoom
+        return "edge";
     } else {
-        var oldOffset = window.scrollX;
-        document.body.scrollLeft = newEdge;
-        if (oldOffset != newEdge) {
+        // Scrolled and zoomed
+        if (newOffset > newEdge) {
+            document.body.scrollLeft = newOffset
             return 0;
         } else {
-            return "edge";
+            var oldOffset = window.scrollX;
+            document.body.scrollLeft = newEdge;
+            if (oldOffset != newEdge) {
+                return 0;
+            } else {
+                return "edge";
+            }
         }
     }
+    
 };
 
 var scrollRight = function(dir) {
     
     var scrollWidth = document.body.scrollWidth;
-    var newOffset = window.scrollX + maxScreenX;
-    var edge = scrollWidth - maxScreenX;
+    var newOffset = window.scrollX + window.innerWidth;
+    var edge = scrollWidth - window.innerWidth;
     var newEdge = (dir == "rtl")? 0:edge
     
-    if (newOffset < newEdge) {
-        document.body.scrollLeft = newOffset
-        return 0;
+    if (window.innerWidth == scrollWidth) {
+        // No scroll and default zoom
+        return "edge";
     } else {
-        var oldOffset = window.scrollX;
-        document.body.scrollLeft = newEdge;
-        if (oldOffset != newEdge) {
+        // Scrolled and zoomed
+        if (newOffset < newEdge) {
+            document.body.scrollLeft = newOffset
             return 0;
         } else {
-            return "edge";
+            var oldOffset = window.scrollX;
+            document.body.scrollLeft = newEdge;
+            if (oldOffset != newEdge) {
+                return 0;
+            } else {
+                return "edge";
+            }
         }
     }
+    
 };
 
 // Snap the offset to the screen width (page width).

--- a/R2Streamer/scripts/utils.js
+++ b/R2Streamer/scripts/utils.js
@@ -52,43 +52,57 @@ var scrollToPosition = function(position, dir) {
 
 var scrollLeft = function(dir) {
     var scrollWidth = document.body.scrollWidth;
-    var newOffset = window.scrollX - maxScreenX;
-    var edge = -scrollWidth + maxScreenX;
+    var newOffset = window.scrollX - window.innerWidth;
+    var edge = -scrollWidth + window.innerWidth;
     var newEdge = (dir == "rtl")? edge:0;
     
-    if (newOffset > newEdge) {
-        document.body.scrollLeft = newOffset
-        return 0;
+    if (window.innerWidth == scrollWidth) {
+        // No scroll and default zoom
+        return "edge";
     } else {
-        var oldOffset = window.scrollX;
-        document.body.scrollLeft = newEdge;
-        if (oldOffset != newEdge) {
+        // Scrolled and zoomed
+        if (newOffset > newEdge) {
+            document.body.scrollLeft = newOffset
             return 0;
         } else {
-            return "edge";
+            var oldOffset = window.scrollX;
+            document.body.scrollLeft = newEdge;
+            if (oldOffset != newEdge) {
+                return 0;
+            } else {
+                return "edge";
+            }
         }
     }
+    
 };
 
 var scrollRight = function(dir) {
     
     var scrollWidth = document.body.scrollWidth;
-    var newOffset = window.scrollX + maxScreenX;
-    var edge = scrollWidth - maxScreenX;
+    var newOffset = window.scrollX + window.innerWidth;
+    var edge = scrollWidth - window.innerWidth;
     var newEdge = (dir == "rtl")? 0:edge
     
-    if (newOffset < newEdge) {
-        document.body.scrollLeft = newOffset
-        return 0;
+    if (window.innerWidth == scrollWidth) {
+        // No scroll and default zoom
+        return "edge";
     } else {
-        var oldOffset = window.scrollX;
-        document.body.scrollLeft = newEdge;
-        if (oldOffset != newEdge) {
+        // Scrolled and zoomed
+        if (newOffset < newEdge) {
+            document.body.scrollLeft = newOffset
             return 0;
         } else {
-            return "edge";
+            var oldOffset = window.scrollX;
+            document.body.scrollLeft = newEdge;
+            if (oldOffset != newEdge) {
+                return 0;
+            } else {
+                return "edge";
+            }
         }
     }
+    
 };
 
 // Snap the offset to the screen width (page width).

--- a/Sources/fetcher/ContentFilter.swift
+++ b/Sources/fetcher/ContentFilter.swift
@@ -248,9 +248,6 @@ final internal class ContentFiltersEpub: ContentFilters {
 
         var includes = [String]()
 
-        includes.append("<meta name=\"viewport\" content=\"width=1024; height=768; left=50%; top=50%; bottom=auto; right=auto; transform=translate(-50%, -50%);\"/>\n")
-        /// Readium CSS -- Pagination.
-        /// Readium JS.
         // Touch event bubbling.
         includes.append(getHtmlScript(forResource: "\(baseUrl)scripts/touchHandling.js"))
         // Misc JS utils.


### PR DESCRIPTION
Fix readium/r2-testapp-swift#137 - FXL: width seems to be too wide and therefore scrollable
Fix readium/r2-testapp-swift#138 - FXL: tap gestures seem to interfere with drag gestures

- Remove the artificially injected viewport when opening a FXL publication to prevent extra spacing
- Position calculation of a tap gesture is updated. Previous calculation for an FXL publication in zoomed mode was always wrong.
- For an FXL publication, scrolling events (left and right) was not handled correctly. This PR fixes this.