### PR TITLE
Add filter for dc:date

### DIFF
--- a/Sources/parser/OPFParser.swift
+++ b/Sources/parser/OPFParser.swift
@@ -91,8 +91,8 @@ final public class OPFParser {
         if let description = metadataElement["dc:description"].value {
             metadata.description = description
         }
-        // After discuss with Laurent, only the `dc:date` element without any attribtes will be considered for the publicaton.
-        // And only the string with full date will be considered as valid date string. 
+        // From the EPUB 2 and EPUB 3 specifications, only the `dc:date` element without any attribtes will be considered for the `published` property.
+        // And only the string with full date will be considered as valid date string. The string format validation happens in the `setter` of `published`.
         if let dateString = metadataElement["dc:date"].all?.filter({ (thisElement) -> Bool in
             return thisElement.attributes.count == 0
         }).first?.value {

--- a/Sources/parser/OPFParser.swift
+++ b/Sources/parser/OPFParser.swift
@@ -91,9 +91,12 @@ final public class OPFParser {
         if let description = metadataElement["dc:description"].value {
             metadata.description = description
         }
-        // Date. (year?)
-        if let date = metadataElement["dc:date"].value {
-            metadata.publicationDate = date
+        // After discuss with Laurent, only the `dc:date` element without any attribtes will be considered for the publicaton.
+        // And only the string with full date will be considered as valid date string. 
+        if let dateString = metadataElement["dc:date"].all?.filter({ (thisElement) -> Bool in
+            return thisElement.attributes.count == 0
+        }).first?.value {
+            metadata.published = dateString
         }
         // Last modification date.
         metadata.modified = MetadataParser.modifiedDate(from: metadataElement)
@@ -344,15 +347,4 @@ final public class OPFParser {
         return properties
     }
 }
-
-
-
-
-
-
-
-
-
-
-
 


### PR DESCRIPTION
This PR simply added a filter to ignore any `dc:date` with any property. It's relying on the date format check in https://github.com/readium/r2-shared-swift/pull/33