### PR TITLE
Fix the touch problem under CJK-vertical

### DIFF
--- a/R2Streamer/scripts/touchHandling.js
+++ b/R2Streamer/scripts/touchHandling.js
@@ -65,17 +65,17 @@ var handleTouchEnd = function(event) {
 
     // Tap to turn.
     if(touchDistance < 0.01) {
-        //var position = Math.abs(touch.clientX % maxScreenX) / maxScreenX;
-        var position;
+        var position = touch.clientX / window.innerWidth;
         
-        if (maxScreenX == window.innerWidth) {
-            // No scroll and default zoom
-            position = touch.clientX / document.body.clientWidth
-        } else {
-            // FXL
-            position = touch.screenX / document.body.clientWidth
-        }
-        
+//        if (maxScreenX == window.innerWidth) {
+//            // No scroll and default zoom
+//            position = touch.clientX / window.innerWidth;
+//        } else {
+//            // FXL
+//            // Looks like this is the ratio in document space instead of screen space
+//            // position = touch.screenX / document.body.clientWidth;
+//        }
+
         if (position <= 0.2) {
             // TAP left.
             console.log("LeftTapped");

--- a/R2Streamer/scripts/utils-old.js
+++ b/R2Streamer/scripts/utils-old.js
@@ -67,14 +67,15 @@ var scrollLeft = function(dir) {
         } else {
             var oldOffset = window.scrollX;
             document.body.scrollLeft = newEdge;
-            if (oldOffset != newEdge) {
+            var diff = Math.abs(newEdge-oldOffset)/window.innerWidth;
+            // In some case the scrollX cannot reach the position respecting to innerWidth
+            if (diff > 0.01) {
                 return 0;
             } else {
                 return "edge";
             }
         }
     }
-    
 };
 
 var scrollRight = function(dir) {
@@ -95,14 +96,15 @@ var scrollRight = function(dir) {
         } else {
             var oldOffset = window.scrollX;
             document.body.scrollLeft = newEdge;
-            if (oldOffset != newEdge) {
+            var diff = Math.abs(newEdge-oldOffset)/window.innerWidth;
+            // In some case the scrollX cannot reach the position respecting to innerWidth
+            if (diff > 0.01) {
                 return 0;
             } else {
                 return "edge";
             }
         }
     }
-    
 };
 
 // Snap the offset to the screen width (page width).

--- a/R2Streamer/scripts/utils.js
+++ b/R2Streamer/scripts/utils.js
@@ -67,14 +67,15 @@ var scrollLeft = function(dir) {
         } else {
             var oldOffset = window.scrollX;
             document.body.scrollLeft = newEdge;
-            if (oldOffset != newEdge) {
+            var diff = Math.abs(newEdge-oldOffset)/window.innerWidth;
+            // In some case the scrollX cannot reach the position respecting to innerWidth
+            if (diff > 0.01) {
                 return 0;
             } else {
                 return "edge";
             }
         }
     }
-    
 };
 
 var scrollRight = function(dir) {
@@ -95,14 +96,15 @@ var scrollRight = function(dir) {
         } else {
             var oldOffset = window.scrollX;
             document.body.scrollLeft = newEdge;
-            if (oldOffset != newEdge) {
+            var diff = Math.abs(newEdge-oldOffset)/window.innerWidth;
+            // In some case the scrollX cannot reach the position respecting to innerWidth
+            if (diff > 0.01) {
                 return 0;
             } else {
                 return "edge";
             }
         }
     }
-    
 };
 
 // Snap the offset to the screen width (page width).

--- a/Sources/fetcher/ContentFilter.swift
+++ b/Sources/fetcher/ContentFilter.swift
@@ -310,6 +310,7 @@ let cjkHorizontalPreset: [ReadiumCSSName: Bool] = [
     .letterSpacing: false]
 
 let cjkVerticalPreset: [ReadiumCSSName: Bool] = [
+    .scroll: true,
     .columnCount: false,
     .textAlignment: false,
     .hyphens: false,


### PR DESCRIPTION
Fix the touch problem under CJK-vertical, 
       ` var position = touch.clientX / window.innerWidth;`

Fix a problem of scrolling on the edge of FXL content. In some case, it cannot reach the exact edge of FXL. So it cannot scroll to another FXL content by tapping.