### PR TITLE
Fix DRM input streams and positionList for LCPDF

### DIFF
--- a/r2-streamer-swift/Fetcher/DRM/DRMInputStream.swift
+++ b/r2-streamer-swift/Fetcher/DRM/DRMInputStream.swift
@@ -42,15 +42,11 @@ class DRMInputStream: SeekableInputStream, Loggable {
         let length = Int64(self.length)
         switch whence {
         case .startOfFile:
-            assert(0...length ~= offset)
-            _offset = UInt64(offset)
+            _offset = UInt64(min(offset, length))
         case .endOfFile:
-            assert(-length...0 ~= offset)
-            _offset = UInt64(length + offset)
+            _offset = UInt64(min(length + offset, length))
         case .currentPosition:
-            let newOffset = Int64(_offset) + offset
-            assert(0...length ~= newOffset)
-            _offset = UInt64(offset)
+            _offset = min(_offset + UInt64(offset), UInt64(length))
         }
     }
     

--- a/r2-streamer-swift/Parser/EPUB/EPUBParser.swift
+++ b/r2-streamer-swift/Parser/EPUB/EPUBParser.swift
@@ -194,9 +194,8 @@ final public class EpubParser: PublicationParser {
         for mediaOverlayLink in mediaOverlays {
             let node = MediaOverlayNode()
             
-            guard let smilDataOptional = try? fetcher.data(forLink: mediaOverlayLink),
-//                let smilData = smilDataOptional,
-                let smilXml = try? XMLDocument(data: smilDataOptional) else
+            guard let smilData = try? fetcher.data(forLink: mediaOverlayLink),
+                let smilXml = try? XMLDocument(data: smilData) else
             {
                 throw OPFParserError.invalidSmilResource
             }

--- a/r2-streamer-swift/Parser/PDF/PDFFileCGParser.swift
+++ b/r2-streamer-swift/Parser/PDF/PDFFileCGParser.swift
@@ -220,8 +220,8 @@ final class PDFFileCGParser: PDFFileParser, Loggable {
                 }
 
                 let current = stream.offset
-                // SeekWhence.currentPosition is not supported at this time
                 do {
+                    // SeekWhence.currentPosition is not supported at this time
                     try stream.seek(offset: Int64(current) + count, whence: .startOfFile)
                 } catch {
                     PDFParser.log(.error, error)

--- a/r2-streamer-swift/Parser/PDF/PDFParser.swift
+++ b/r2-streamer-swift/Parser/PDF/PDFParser.swift
@@ -190,9 +190,10 @@ public final class PDFParser: PublicationParser, Loggable {
 
             // Calculates the page count of each resource from the reading order.
             let resources = publication.readingOrder.map { link -> (Int, Link) in
-                guard let optionalData = try? fetcher.data(forLink: link),
-//                    let data = optionalData,
-                    let parser = try? parserType.init(stream: DataInputStream(data: optionalData)),
+                guard let stream = try? fetcher.dataStream(forLink: link),
+                    // FIXME: We should be able to use the stream directly here instead of reading it fully into a Data object, but somehow it fails with random access in CBCDRMInputStream.
+                    let data = try? Data.reading(stream),
+                    let parser = try? parserType.init(stream: DataInputStream(data: data)),
                     let pageCount = try? parser.parseNumberOfPages() else
                 {
                     log(.warning, "Can't get the number of pages from PDF document at \(link)")


### PR DESCRIPTION
1. Reading an `InputStream` with a `maxLength` bigger than EOF must be authorized, which was not the case in the DRM input streams.

2. Fix creating the `positionList` with LCPDF, which requires to parse the PDF with Core Graphics when parsing the `Publication` to get the number of pages. This fix is not entirely satisfying because we need to read the PDF fully instead of relying on random access with `CBCDRMInputStream` ([I opened an issue for this problem](https://github.com/readium/r2-streamer-swift/issues/141)).
https://github.com/readium/r2-streamer-swift/blob/1de6db2cf5c72e88384d238454a6fd8b9746022f/r2-streamer-swift/Parser/PDF/PDFParser.swift#L193-L197