### PR TITLE
Improve performances when opening large LCPDFs

### DIFF
--- a/r2-streamer-swift/Parser/PDF/PDFParser.swift
+++ b/r2-streamer-swift/Parser/PDF/PDFParser.swift
@@ -192,7 +192,7 @@ public final class PDFParser: PublicationParser, Loggable {
             let resources = publication.readingOrder.map { link -> (Int, Link) in
                 guard let stream = try? fetcher.dataStream(forLink: link),
                     // FIXME: We should be able to use the stream directly here instead of reading it fully into a Data object, but somehow it fails with random access in CBCDRMInputStream.
-                    let data = try? Data.reading(stream),
+                    let data = try? Data.reading(stream, bufferSize: 500000 /* 500 KB */),
                     let parser = try? parserType.init(stream: DataInputStream(data: data)),
                     let pageCount = try? parser.parseNumberOfPages() else
                 {

--- a/r2-streamer-swift/Toolkit/DataExtension.swift
+++ b/r2-streamer-swift/Toolkit/DataExtension.swift
@@ -13,7 +13,7 @@ import Foundation
 
 extension Data {
     
-    static func reading(_ stream: InputStream) throws -> Data {
+    static func reading(_ stream: InputStream, bufferSize: Int = 32768) throws -> Data {
         if let dataStream = stream as? DataInputStream {
             return dataStream.data
         }
@@ -24,7 +24,6 @@ extension Data {
             stream.close()
         }
 
-        let bufferSize = 1024
         let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
         defer {
             buffer.deallocate()


### PR DESCRIPTION
The buffer length used to read a LCPDF was too small, which took ages to open a large one (> 50 MB).