### PR TITLE
Add onCreatePublication to Streamer.open()

### DIFF
--- a/r2-streamer-swift/Streamer.swift
+++ b/r2-streamer-swift/Streamer.swift
@@ -82,8 +82,11 @@ public final class Streamer: Loggable {
     ///     publication, for example a password.
     ///   - sender: Free object that can be used by reading apps to give some UX context when
     ///     presenting dialogs.
+    ///   - onCreatePublication: Transformation which will be applied on the Publication Builder.
+    ///     It can be used to modify the `Manifest`, the root `Fetcher` or the list of service
+    ///     factories of the `Publication`.
     ///   - warnings: Logger used to broadcast non-fatal parsing warnings.
-    public func open(file: File, allowUserInteraction: Bool, credentials: String? = nil, sender: Any? = nil, warnings: WarningLogger? = nil, completion: @escaping (CancellableResult<Publication, Publication.OpeningError>) -> Void) {
+    public func open(file: File, allowUserInteraction: Bool, credentials: String? = nil, sender: Any? = nil, warnings: WarningLogger? = nil, onCreatePublication: Publication.Builder.Transform? = nil, completion: @escaping (CancellableResult<Publication, Publication.OpeningError>) -> Void) {
         log(.info, "Open \(file.url.lastPathComponent)")
 
         return createFetcher(for: file, allowUserInteraction: allowUserInteraction, password: credentials, sender: sender)
@@ -93,7 +96,7 @@ public final class Streamer: Loggable {
             }
             .flatMap { file in
                 // Parses the Publication using the parsers.
-                self.parsePublication(from: file, warnings: warnings)
+                self.parsePublication(from: file, warnings: warnings, onCreatePublication: onCreatePublication)
             }
             .resolve(on: .main, completion)
     }
@@ -150,7 +153,7 @@ public final class Streamer: Loggable {
     }
     
     /// Parses the `Publication` from the provided file and the `parsers`.
-    private func parsePublication(from file: PublicationFile, warnings: WarningLogger?) -> Deferred<Publication, Publication.OpeningError> {
+    private func parsePublication(from file: PublicationFile, warnings: WarningLogger?, onCreatePublication: Publication.Builder.Transform?) -> Deferred<Publication, Publication.OpeningError> {
         return deferred(on: .global(qos: .userInitiated)) {
             var parsers = self.parsers
             var parsedBuilder: Publication.Builder?
@@ -168,8 +171,12 @@ public final class Streamer: Loggable {
             
             // Transform from the Content Protection.
             builder.apply(file.onCreatePublication)
-            // Transform provided by the reading app.
+            // Transform provided by the reading app during the construction of the `Streamer`.
             builder.apply(self.onCreatePublication)
+            // Transform provided by the reading app in `Streamer.open()`.
+            if let onCreatePublication = onCreatePublication {
+                builder.apply(onCreatePublication)
+            }
 
             return .success(builder.build())
         }


### PR DESCRIPTION
This allows to modify a `Publication` from a closure provided to `Streamer.open()`. For example, to merge the Publication metadata with some metadata pulled from a database or OPDS publication.

Compared to the `onCreatePublication` provided to `Streamer`'s constructor, this can be use to tailor the transformation to a particular publication, for example by using a db model in the transform.