### PR TITLE
Decode resource href before searching into archive

### DIFF
--- a/r2-streamer-swift/Server/PublicationServer.swift
+++ b/r2-streamer-swift/Server/PublicationServer.swift
@@ -224,7 +224,7 @@ public class PublicationServer: ResourcesServer {
                 href = String(href[range.upperBound...])
             }
 
-            let resource = publication.get(href.removingPercentEncoding!)
+            let resource = publication.get(href.removingPercentEncoding ?? href)
             switch resource.stream() {
             case .success(let stream):
                 let range = request.hasByteRange() ? request.byteRange : nil

--- a/r2-streamer-swift/Server/PublicationServer.swift
+++ b/r2-streamer-swift/Server/PublicationServer.swift
@@ -224,7 +224,7 @@ public class PublicationServer: ResourcesServer {
                 href = String(href[range.upperBound...])
             }
 
-            let resource = publication.get(href)
+            let resource = publication.get(href.removingPercentEncoding!)
             switch resource.stream() {
             case .success(let stream):
                 let range = request.hasByteRange() ? request.byteRange : nil


### PR DESCRIPTION
Encoded href for resources are not decoded and it failed if the publication is an archive (zipped audio book for instance).
The resource is not found in the archive.