### PR TITLE
Replace File with PublicationAsset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+* `Streamer` is now expecting a `PublicationAsset` instead of a `File`. You can create custom implementations of
+`PublicationAsset` to open a publication from different medium, such as a file, a remote URL, in-memory bytes, etc.
+  * `FileAsset` can be used to replace `File` and provides the same behavior.
+  
 
 ## [2.0.0-alpha.2]
 

--- a/r2-streamer-swift/Parser/Audio/AudioParser.swift
+++ b/r2-streamer-swift/Parser/Audio/AudioParser.swift
@@ -20,8 +20,8 @@ public final class AudioParser: PublicationParser {
     
     public init() {}
     
-    public func parse(file: File, fetcher: Fetcher, warnings: WarningLogger?) throws -> Publication.Builder? {
-        guard accepts(file, fetcher) else {
+    public func parse(asset: PublicationAsset, fetcher: Fetcher, warnings: WarningLogger?) throws -> Publication.Builder? {
+        guard accepts(asset, fetcher) else {
             return nil
         }
         
@@ -38,7 +38,7 @@ public final class AudioParser: PublicationParser {
             format: .cbz,
             manifest: Manifest(
                 metadata: Metadata(
-                    title: fetcher.guessTitle(ignoring: ignores) ?? file.name
+                    title: fetcher.guessTitle(ignoring: ignores) ?? asset.name
                 ),
                 readingOrder: readingOrder
             ),
@@ -49,8 +49,8 @@ public final class AudioParser: PublicationParser {
         )
     }
     
-    private func accepts(_ file: File, _ fetcher: Fetcher) -> Bool {
-        if file.format == .zab {
+    private func accepts(_ asset: PublicationAsset, _ fetcher: Fetcher) -> Bool {
+        if asset.format == .zab {
             return true
         }
         

--- a/r2-streamer-swift/Parser/Audio/AudioParser.swift
+++ b/r2-streamer-swift/Parser/Audio/AudioParser.swift
@@ -50,7 +50,7 @@ public final class AudioParser: PublicationParser {
     }
     
     private func accepts(_ asset: PublicationAsset, _ fetcher: Fetcher) -> Bool {
-        if asset.format == .zab {
+        if asset.mediaType() == .zab {
             return true
         }
         

--- a/r2-streamer-swift/Parser/Audio/Services/AudioLocatorService.swift
+++ b/r2-streamer-swift/Parser/Audio/Services/AudioLocatorService.swift
@@ -33,7 +33,7 @@ final class AudioLocatorService: LocatorService {
         if let totalProgression = locator.locations.totalProgression, let target = locate(progression: totalProgression) {
             return target.copy(
                 title: locator.title,
-                text: locator.text
+                text: { $0 = locator.text }
             )
         }
         

--- a/r2-streamer-swift/Parser/Audio/Services/AudioLocatorService.swift
+++ b/r2-streamer-swift/Parser/Audio/Services/AudioLocatorService.swift
@@ -79,12 +79,11 @@ final class AudioLocatorService: LocatorService {
         var current: Double = 0
         for (i, duration) in durations.enumerated() {
             let link = readingOrder[i]
-            let itemDuration = link.duration ?? 0
-            if current..<current+itemDuration ~= position {
+            if current..<current+duration ~= position {
                 return (link, startPosition: current)
             }
             
-            current += itemDuration
+            current += duration
         }
         
         if position == totalDuration, let link = readingOrder.last {

--- a/r2-streamer-swift/Parser/EPUB/EPUBParser.swift
+++ b/r2-streamer-swift/Parser/EPUB/EPUBParser.swift
@@ -48,8 +48,8 @@ final public class EPUBParser: PublicationParser {
     
     public init() {}
     
-    public func parse(file: File, fetcher: Fetcher, warnings: WarningLogger?) throws -> Publication.Builder? {
-        guard file.format == .epub else {
+    public func parse(asset: PublicationAsset, fetcher: Fetcher, warnings: WarningLogger?) throws -> Publication.Builder? {
+        guard asset.format == .epub else {
             return nil
         }
         
@@ -59,7 +59,7 @@ final public class EPUBParser: PublicationParser {
         let encryptions = (try? EPUBEncryptionParser(fetcher: fetcher))?.parseEncryptions() ?? [:]
 
         // Extracts metadata and links from the OPF.
-        let components = try OPFParser(fetcher: fetcher, opfHREF: opfHREF, fallbackTitle: file.name, encryptions: encryptions).parsePublication()
+        let components = try OPFParser(fetcher: fetcher, opfHREF: opfHREF, fallbackTitle: asset.name, encryptions: encryptions).parsePublication()
         let metadata = components.metadata
         let links = components.readingOrder + components.resources
         

--- a/r2-streamer-swift/Parser/EPUB/EPUBParser.swift
+++ b/r2-streamer-swift/Parser/EPUB/EPUBParser.swift
@@ -49,7 +49,7 @@ final public class EPUBParser: PublicationParser {
     public init() {}
     
     public func parse(asset: PublicationAsset, fetcher: Fetcher, warnings: WarningLogger?) throws -> Publication.Builder? {
-        guard asset.format == .epub else {
+        guard asset.mediaType() == .epub else {
             return nil
         }
         

--- a/r2-streamer-swift/Parser/EPUB/Resource Transformers/EPUBHTMLInjector.swift
+++ b/r2-streamer-swift/Parser/EPUB/Resource Transformers/EPUBHTMLInjector.swift
@@ -34,12 +34,7 @@ final class EPUBHTMLInjector {
         }
 
         return resource.mapAsString { [metadata] content in
-            guard let document = try? XMLDocument(string: content) else {
-                return content
-            }
-
             var content = content
-            let language = metadata.languages.first ?? document.root?.attr("lang")
 
             // User properties injection
             if let htmlStart = content.endIndex(of: "<html") {

--- a/r2-streamer-swift/Parser/Image/CBZParser.swift
+++ b/r2-streamer-swift/Parser/Image/CBZParser.swift
@@ -23,8 +23,8 @@ public typealias CbzParserError = CBZParserError
 @available(*, unavailable, message: "Use `ImageParser` instead")
 public class CbzParser: PublicationParser {
     
-    public func parse(file: File, fetcher: Fetcher, warnings: WarningLogger?) throws -> Publication.Builder? {
-        return try ImageParser().parse(file: file, fetcher: fetcher, warnings: warnings)
+    public func parse(asset: PublicationAsset, fetcher: Fetcher, warnings: WarningLogger?) throws -> Publication.Builder? {
+        return try ImageParser().parse(asset: asset, fetcher: fetcher, warnings: warnings)
     }
 
 }

--- a/r2-streamer-swift/Parser/Image/ImageParser.swift
+++ b/r2-streamer-swift/Parser/Image/ImageParser.swift
@@ -19,9 +19,9 @@ import R2Shared
 public final class ImageParser: PublicationParser {
     
     public init() {}
-
-    public func parse(file: File, fetcher: Fetcher, warnings: WarningLogger?) throws -> Publication.Builder? {
-        guard accepts(file, fetcher) else {
+    
+    public func parse(asset: PublicationAsset, fetcher: Fetcher, warnings: WarningLogger?) throws -> Publication.Builder? {
+        guard accepts(asset, fetcher) else {
             return nil
         }
         
@@ -41,7 +41,7 @@ public final class ImageParser: PublicationParser {
             format: .cbz,
             manifest: Manifest(
                 metadata: Metadata(
-                    title: fetcher.guessTitle(ignoring: ignores) ?? file.name
+                    title: fetcher.guessTitle(ignoring: ignores) ?? asset.name
                 ),
                 readingOrder: readingOrder
             ),
@@ -52,8 +52,8 @@ public final class ImageParser: PublicationParser {
         )
     }
     
-    private func accepts(_ file: File, _ fetcher: Fetcher) -> Bool {
-        if file.format == .cbz {
+    private func accepts(_ asset: PublicationAsset, _ fetcher: Fetcher) -> Bool {
+        if asset.format == .cbz {
             return true
         }
         

--- a/r2-streamer-swift/Parser/Image/ImageParser.swift
+++ b/r2-streamer-swift/Parser/Image/ImageParser.swift
@@ -53,7 +53,7 @@ public final class ImageParser: PublicationParser {
     }
     
     private func accepts(_ asset: PublicationAsset, _ fetcher: Fetcher) -> Bool {
-        if asset.format == .cbz {
+        if asset.mediaType() == .cbz {
             return true
         }
         

--- a/r2-streamer-swift/Parser/PDF/PDFParser.swift
+++ b/r2-streamer-swift/Parser/PDF/PDFParser.swift
@@ -39,7 +39,7 @@ public final class PDFParser: PublicationParser, Loggable {
     }
     
     public func parse(asset: PublicationAsset, fetcher: Fetcher, warnings: WarningLogger?) throws -> Publication.Builder? {
-        guard asset.format == .pdf else {
+        guard asset.mediaType() == .pdf else {
             return nil
         }
        

--- a/r2-streamer-swift/Parser/PublicationParser.swift
+++ b/r2-streamer-swift/Parser/PublicationParser.swift
@@ -7,21 +7,21 @@
 import Foundation
 import R2Shared
 
-/// Parses a Publication from a file.
+/// Parses a Publication from an asset.
 public protocol PublicationParser {
     
-    /// Constructs a `Publication.Builder` to build a `Publication` from a publication file.
+    /// Constructs a `Publication.Builder` to build a `Publication` from a publication asset.
     ///
     /// - Parameters:
-    ///   - file: Path to the publication file.
+    ///   - asset: Digital medium (e.g. a file) used to access the publication.
     ///   - fetcher: Initial leaf fetcher which should be used to read the publication's resources.
     ///     This can be used to:
     ///       - support content protection technologies
     ///       - parse exploded archives or in archiving formats unknown to the parser, e.g. RAR
-    ///     If the file is not an archive, it will be reachable at the HREF /<file.name>.
+    ///     If the asset is not an archive, it will be reachable at the HREF /<asset.name>.
     ///   - warnings: Used to report non-fatal parsing warnings, such as publication authoring
     ///     mistakes. This is useful to warn users of potential rendering issues or help authors
     ///     debug their publications.
-    func parse(file: File, fetcher: Fetcher, warnings: WarningLogger?) throws -> Publication.Builder?
+    func parse(asset: PublicationAsset, fetcher: Fetcher, warnings: WarningLogger?) throws -> Publication.Builder?
 
 }

--- a/r2-streamer-swift/Parser/Readium/ReadiumWebPubParser.swift
+++ b/r2-streamer-swift/Parser/Readium/ReadiumWebPubParser.swift
@@ -32,7 +32,7 @@ public class ReadiumWebPubParser: PublicationParser, Loggable {
     }
     
     public func parse(asset: PublicationAsset, fetcher: Fetcher, warnings: WarningLogger?) throws -> Publication.Builder? {
-        guard let mediaType = asset.format, mediaType.isReadiumWebPubProfile else {
+        guard let mediaType = asset.mediaType(), mediaType.isReadiumWebPubProfile else {
             return nil
         }
         
@@ -73,7 +73,7 @@ public class ReadiumWebPubParser: PublicationParser, Loggable {
             format: (mediaType.matches(.lcpProtectedPDF) ? .pdf : .webpub),
             manifest: manifest,
             fetcher: fetcher,
-            servicesBuilder: PublicationServicesBuilder {
+            servicesBuilder: PublicationServicesBuilder(setup:  {
                 switch mediaType {
                 case .lcpProtectedPDF:
                     $0.setPositionsServiceFactory(LCPDFPositionsService.makeFactory(pdfFactory: self.pdfFactory))
@@ -84,7 +84,7 @@ public class ReadiumWebPubParser: PublicationParser, Loggable {
                 default:
                     break
                 }
-            }
+            })
         )
     }
 

--- a/r2-streamer-swift/Parser/Readium/ReadiumWebPubParser.swift
+++ b/r2-streamer-swift/Parser/Readium/ReadiumWebPubParser.swift
@@ -31,8 +31,8 @@ public class ReadiumWebPubParser: PublicationParser, Loggable {
         self.pdfFactory = pdfFactory
     }
     
-    public func parse(file: File, fetcher: Fetcher, warnings: WarningLogger?) throws -> Publication.Builder? {
-        guard let mediaType = file.format, mediaType.isReadiumWebPubProfile else {
+    public func parse(asset: PublicationAsset, fetcher: Fetcher, warnings: WarningLogger?) throws -> Publication.Builder? {
+        guard let mediaType = asset.format, mediaType.isReadiumWebPubProfile else {
             return nil
         }
         

--- a/r2-streamer-swiftTests/Parser/Audio/AudioParserTests.swift
+++ b/r2-streamer-swiftTests/Parser/Audio/AudioParserTests.swift
@@ -18,40 +18,40 @@ class AudioParserTests: XCTestCase {
     let fixtures = Fixtures()
     var parser: AudioParser!
     
-    var zabFile: File!
+    var zabAsset: FileAsset!
     var zabFetcher: Fetcher!
     
-    var mp3File: File!
+    var mp3Asset: FileAsset!
     var mp3Fetcher: Fetcher!
     
     override func setUpWithError() throws {
         parser = AudioParser()
         
-        zabFile = File(url: fixtures.url(for: "audiotest.zab"))
-        zabFetcher = try ArchiveFetcher(url: zabFile.url)
+        zabAsset = FileAsset(url: fixtures.url(for: "audiotest.zab"))
+        zabFetcher = try ArchiveFetcher(url: zabAsset.url)
         
-        mp3File = File(url: fixtures.url(for: "audiotest/Test Audiobook/Latin.mp3"))
-        mp3Fetcher = FileFetcher(href: "/Latin.mp3", path: mp3File.url)
+        mp3Asset = FileAsset(url: fixtures.url(for: "audiotest/Test Audiobook/Latin.mp3"))
+        mp3Fetcher = FileFetcher(href: "/Latin.mp3", path: mp3Asset.url)
     }
     
     func testRefusesNonAudioBased() throws {
-        let file = File(url: fixtures.url(for: "cc-shared-culture.epub"))
-        let fetcher = try ArchiveFetcher(url: file.url)
-        XCTAssertNil(try parser.parse(file: file, fetcher: fetcher, warnings: nil))
+        let asset = FileAsset(url: fixtures.url(for: "cc-shared-culture.epub"))
+        let fetcher = try ArchiveFetcher(url: asset.url)
+        XCTAssertNil(try parser.parse(asset: asset, fetcher: fetcher, warnings: nil))
     }
     
     func testAcceptsZAB() {
-        XCTAssertNotNil(try parser.parse(file: zabFile, fetcher: zabFetcher, warnings: nil))
+        XCTAssertNotNil(try parser.parse(asset: zabAsset, fetcher: zabFetcher, warnings: nil))
     }
     
     func testAcceptsMP3() {
-        XCTAssertNotNil(try parser.parse(file: mp3File, fetcher: mp3Fetcher, warnings: nil))
+        XCTAssertNotNil(try parser.parse(asset: mp3Asset, fetcher: mp3Fetcher, warnings: nil))
     }
     
     /// The reading order is sorted alphabetically, ignores Thumbs.db, hidden files and non-audio
     /// files.
     func testReadingOrderIsSortedAlphabetically() throws {
-        let publication = try XCTUnwrap(parser.parse(file: zabFile, fetcher: zabFetcher, warnings: nil)?.build())
+        let publication = try XCTUnwrap(parser.parse(asset: zabAsset, fetcher: zabFetcher, warnings: nil)?.build())
         
         XCTAssertEqual(publication.readingOrder, [
             Link(href: "/Test Audiobook/gtr-jazz.mp3", type: "audio/mpeg", properties: Properties(["compressedLength": 150237])),
@@ -61,17 +61,17 @@ class AudioParserTests: XCTestCase {
     }
     
     func testHasNoCover() throws {
-        let publication = try XCTUnwrap(parser.parse(file: zabFile, fetcher: zabFetcher, warnings: nil)?.build())
+        let publication = try XCTUnwrap(parser.parse(asset: zabAsset, fetcher: zabFetcher, warnings: nil)?.build())
         XCTAssertNil(publication.link(withRel: .cover))
     }
     
     func testComputeTitleFromArchiveRootDirectory() throws {
-        let publication = try XCTUnwrap(parser.parse(file: zabFile, fetcher: zabFetcher, warnings: nil)?.build())
+        let publication = try XCTUnwrap(parser.parse(asset: zabAsset, fetcher: zabFetcher, warnings: nil)?.build())
         XCTAssertEqual(publication.metadata.title, "Test Audiobook")
     }
     
     func testHasNoPositions() throws {
-        let publication = try XCTUnwrap(parser.parse(file: zabFile, fetcher: zabFetcher, warnings: nil)?.build())
+        let publication = try XCTUnwrap(parser.parse(asset: zabAsset, fetcher: zabFetcher, warnings: nil)?.build())
         
         XCTAssertEqual(publication.positions.count, 0)
     }

--- a/r2-streamer-swiftTests/Parser/EPUB/Services/EPUBPositionsServiceTests.swift
+++ b/r2-streamer-swiftTests/Parser/EPUB/Services/EPUBPositionsServiceTests.swift
@@ -426,6 +426,7 @@ private class MockFetcher: Fetcher {
     struct MockResource: Resource {
 
         let link: Link
+        let file: URL? = nil
         var length: ResourceResult<UInt64> { .success(_length) }
         
         private let _length: UInt64

--- a/r2-streamer-swiftTests/Parser/Image/ImageParserTests.swift
+++ b/r2-streamer-swiftTests/Parser/Image/ImageParserTests.swift
@@ -18,40 +18,40 @@ class ImageParserTests: XCTestCase {
     let fixtures = Fixtures()
     var parser: ImageParser!
     
-    var cbzFile: File!
+    var cbzAsset: FileAsset!
     var cbzFetcher: Fetcher!
     
-    var jpgFile: File!
+    var jpgAsset: FileAsset!
     var jpgFetcher: Fetcher!
 
     override func setUpWithError() throws {
         parser = ImageParser()
         
-        cbzFile = File(url: fixtures.url(for: "futuristic_tales.cbz"))
-        cbzFetcher = try ArchiveFetcher(url: cbzFile.url)
+        cbzAsset = FileAsset(url: fixtures.url(for: "futuristic_tales.cbz"))
+        cbzFetcher = try ArchiveFetcher(url: cbzAsset.url)
         
-        jpgFile = File(url: fixtures.url(for: "futuristic_tales/Cory Doctorow's Futuristic Tales of the Here and Now/a-fc.jpg"))
-        jpgFetcher = FileFetcher(href: "/a-fc.jpg", path: jpgFile.url)
+        jpgAsset = FileAsset(url: fixtures.url(for: "futuristic_tales/Cory Doctorow's Futuristic Tales of the Here and Now/a-fc.jpg"))
+        jpgFetcher = FileFetcher(href: "/a-fc.jpg", path: jpgAsset.url)
     }
     
     func testRefusesNonBitmapBased() throws {
-        let file = File(url: fixtures.url(for: "cc-shared-culture.epub"))
-        let fetcher = try ArchiveFetcher(url: file.url)
-        XCTAssertNil(try parser.parse(file: file, fetcher: fetcher, warnings: nil))
+        let asset = FileAsset(url: fixtures.url(for: "cc-shared-culture.epub"))
+        let fetcher = try ArchiveFetcher(url: asset.url)
+        XCTAssertNil(try parser.parse(asset: asset, fetcher: fetcher, warnings: nil))
     }
     
     func testAcceptsCBZ() {
-        XCTAssertNotNil(try parser.parse(file: cbzFile, fetcher: cbzFetcher, warnings: nil))
+        XCTAssertNotNil(try parser.parse(asset: cbzAsset, fetcher: cbzFetcher, warnings: nil))
     }
     
     func testAcceptsJPG() {
-        XCTAssertNotNil(try parser.parse(file: jpgFile, fetcher: jpgFetcher, warnings: nil))
+        XCTAssertNotNil(try parser.parse(asset: jpgAsset, fetcher: jpgFetcher, warnings: nil))
     }
 
     /// The reading order is sorted alphabetically, ignores Thumbs.db, hidden files and non-bitmap
     /// files.
     func testReadingOrderIsSortedAlphabetically() throws {
-        let publication = try XCTUnwrap(parser.parse(file: cbzFile, fetcher: cbzFetcher, warnings: nil)?.build())
+        let publication = try XCTUnwrap(parser.parse(asset: cbzAsset, fetcher: cbzFetcher, warnings: nil)?.build())
         
         XCTAssertEqual(publication.readingOrder, [
             Link(href: "/Cory Doctorow's Futuristic Tales of the Here and Now/a-fc.jpg", type: "image/jpeg", rels: [.cover], properties: Properties(["compressedLength": 145844])),
@@ -63,18 +63,18 @@ class ImageParserTests: XCTestCase {
     }
     
     func testFirstReadingOrderItemIsCover() throws {
-        let publication = try XCTUnwrap(parser.parse(file: cbzFile, fetcher: cbzFetcher, warnings: nil)?.build())
+        let publication = try XCTUnwrap(parser.parse(asset: cbzAsset, fetcher: cbzFetcher, warnings: nil)?.build())
         let cover = try XCTUnwrap(publication.link(withRel: .cover))
         XCTAssertEqual(publication.readingOrder.first, cover)
     }
     
     func testComputeTitleFromArchiveRootDirectory() throws {
-        let publication = try XCTUnwrap(parser.parse(file: cbzFile, fetcher: cbzFetcher, warnings: nil)?.build())
+        let publication = try XCTUnwrap(parser.parse(asset: cbzAsset, fetcher: cbzFetcher, warnings: nil)?.build())
         XCTAssertEqual(publication.metadata.title, "Cory Doctorow's Futuristic Tales of the Here and Now")
     }
     
     func testPositions() throws {
-        let publication = try XCTUnwrap(parser.parse(file: cbzFile, fetcher: cbzFetcher, warnings: nil)?.build())
+        let publication = try XCTUnwrap(parser.parse(asset: cbzAsset, fetcher: cbzFetcher, warnings: nil)?.build())
         
         XCTAssertEqual(publication.positions, [
             Locator(

--- a/r2-streamer-swiftTests/Parser/PublicationParsingTests.swift
+++ b/r2-streamer-swiftTests/Parser/PublicationParsingTests.swift
@@ -36,7 +36,7 @@ class PublicationParsingTests: XCTestCase, Loggable {
     private func parse(url: URL) {
         let expect = expectation(description: "Publication parsed")
     
-        streamer.open(file: File(url: url), allowUserInteraction: false) { result in
+        streamer.open(asset: FileAsset(url: url), allowUserInteraction: false) { result in
             switch result {
             case .success:
                 expect.fulfill()

--- a/r2-streamer-swiftTests/Parser/Readium/ReadiumWebPubParserTests.swift
+++ b/r2-streamer-swiftTests/Parser/Readium/ReadiumWebPubParserTests.swift
@@ -18,45 +18,45 @@ class ReadiumWebPubParserTests: XCTestCase {
     let fixtures = Fixtures()
     var parser: ReadiumWebPubParser!
     
-    var manifestFile: File!
+    var manifestAsset: FileAsset!
     var manifestFetcher: Fetcher!
     
-    var packageFile: File!
+    var packageAsset: FileAsset!
     var packageFetcher: Fetcher!
     
-    var lcpdfFile: File!
+    var lcpdfAsset: FileAsset!
     var lcpdfFetcher: Fetcher!
     
     override func setUpWithError() throws {
         parser = ReadiumWebPubParser()
 
-        manifestFile = File(url: fixtures.url(for: "flatland.json"))
-        manifestFetcher = FileFetcher(href: "/flatland.json", path: manifestFile.url)
+        manifestAsset = FileAsset(url: fixtures.url(for: "flatland.json"))
+        manifestFetcher = FileFetcher(href: "/flatland.json", path: manifestAsset.url)
         
-        packageFile = File(url: fixtures.url(for: "audiotest.lcpa"))
-        packageFetcher = try ArchiveFetcher(url: packageFile.url)
+        packageAsset = FileAsset(url: fixtures.url(for: "audiotest.lcpa"))
+        packageFetcher = try ArchiveFetcher(url: packageAsset.url)
         
-        lcpdfFile = File(url: fixtures.url(for: "daisy.lcpdf"))
-        lcpdfFetcher = try ArchiveFetcher(url: lcpdfFile.url)
+        lcpdfAsset = FileAsset(url: fixtures.url(for: "daisy.lcpdf"))
+        lcpdfFetcher = try ArchiveFetcher(url: lcpdfAsset.url)
     }
     
     func testRefusesNonReadiumWebPub() throws {
-        let file = File(url: fixtures.url(for: "cc-shared-culture.epub"))
-        let fetcher = try ArchiveFetcher(url: file.url)
-        XCTAssertNil(try parser.parse(file: file, fetcher: fetcher, warnings: nil))
+        let asset = FileAsset(url: fixtures.url(for: "cc-shared-culture.epub"))
+        let fetcher = try ArchiveFetcher(url: asset.url)
+        XCTAssertNil(try parser.parse(asset: asset, fetcher: fetcher, warnings: nil))
     }
     
     func testAcceptsManifest() {
-        XCTAssertNotNil(try parser.parse(file: manifestFile, fetcher: manifestFetcher, warnings: nil))
+        XCTAssertNotNil(try parser.parse(asset: manifestAsset, fetcher: manifestFetcher, warnings: nil))
     }
     
     func testAcceptsPackage() {
-        XCTAssertNotNil(try parser.parse(file: packageFile, fetcher: packageFetcher, warnings: nil))
+        XCTAssertNotNil(try parser.parse(asset: packageAsset, fetcher: packageFetcher, warnings: nil))
     }
     
     /// The `Link`s' hrefs are normalized to the `self` link for a manifest.
     func testHrefsAreNormalizedToSelfForManifests() throws {
-        let publication = try XCTUnwrap(try parser.parse(file: manifestFile, fetcher: manifestFetcher, warnings: nil)?.build())
+        let publication = try XCTUnwrap(try parser.parse(asset: manifestAsset, fetcher: manifestFetcher, warnings: nil)?.build())
 
         XCTAssertEqual(
             publication.readingOrder.map { $0.href },
@@ -70,7 +70,7 @@ class ReadiumWebPubParserTests: XCTestCase {
     
     /// The `Link`s' hrefs are normalized to `/` for a package.
     func testHrefsAreNormalizedToRootForPackages() throws {
-        let publication = try XCTUnwrap(parser.parse(file: packageFile, fetcher: packageFetcher, warnings: nil)?.build())
+        let publication = try XCTUnwrap(parser.parse(asset: packageAsset, fetcher: packageFetcher, warnings: nil)?.build())
 
         XCTAssertEqual(
             publication.readingOrder.map { $0.href },

--- a/r2-streamer-swiftTests/Server/PublicationServerTests.swift
+++ b/r2-streamer-swiftTests/Server/PublicationServerTests.swift
@@ -32,7 +32,7 @@ class PublicationServerTests: XCTestCase, Loggable {
     private func testPublication(at url: URL) {
         let expect = expectation(description: "Publication tested")
         
-        streamer.open(file: File(url: url), allowUserInteraction: false) { [self] result in
+        streamer.open(asset: FileAsset(url: url), allowUserInteraction: false) { [self] result in
             guard case .success(let publication) = result else {
                 XCTFail("Failed to parse \(url)")
                 return


### PR DESCRIPTION
* `Streamer` is now expecting a `PublicationAsset` instead of a `File`. You can create custom implementations of
`PublicationAsset` to open a publication from different medium, such as a file, a remote URL, in-memory bytes, etc.
  * `FileAsset` can be used to replace `File` and provides the same behavior.
