### PR TITLE
Fix protection selection for file unlock

### DIFF
--- a/r2-streamer-swift/Streamer.swift
+++ b/r2-streamer-swift/Streamer.swift
@@ -139,8 +139,8 @@ public final class Streamer: Loggable {
     private func openFile(at file: File, with fetcher: Fetcher, credentials: String?, allowUserInteraction: Bool, sender: Any?) -> Deferred<PublicationFile, Publication.OpeningError> {
         func unlock(using protections: [ContentProtection]) -> Deferred<ProtectedFile?, Publication.OpeningError> {
             return deferred {
-                var protections = protections
-                guard let protection = protections.popFirst() else {
+                var protectionList = protections
+                guard let protection = protectionList.popFirst() else {
                     // No Content Protection applied, this file is probably not protected.
                     return .success(nil)
                 }


### PR DESCRIPTION
Protected file can not be unlock because the `protections` were overridden.