### PR TITLE
Disable HTTP caching when serving publication resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+* The HTTP server now requests that publication resources are not cached by browsers.
+  * Caching poses a security risk for protected publications.
 * CocoaPods is not supported anymore.
 
 

--- a/r2-streamer-swift/Server/WebServerResourceResponse.swift
+++ b/r2-streamer-swift/Server/WebServerResourceResponse.swift
@@ -86,6 +86,13 @@ open class WebServerResourceResponse: GCDWebServerFileResponse {
             self.range = 0..<streamLength
         }
         super.init()
+
+        // Disable HTTP caching for publication resources, because it poses a security threat for protected
+        // publications.
+        setValue("no-cache, no-store, must-revalidate", forAdditionalHeader: "Cache-Control")
+        setValue("no-cache", forAdditionalHeader: "Pragma")
+        setValue("0", forAdditionalHeader: "Expires")
+
         // Response
         if let range = self.range {
             let lower = range.lowerBound


### PR DESCRIPTION
* The HTTP server now requests that publication resources are not cached by browsers.
  * Caching poses a security risk for protected publications.