### PR TITLE
Use the new Archive API and simplify serving a Resource from the HTTP server

### DIFF
--- a/r2-streamer-swift/Server/PublicationServer.swift
+++ b/r2-streamer-swift/Server/PublicationServer.swift
@@ -226,19 +226,12 @@ public class PublicationServer: ResourcesServer {
             }
 
             let resource = publication.get(href.removingPercentEncoding ?? href)
-            switch resource.stream() {
-            case .success(let stream):
-                let range = request.hasByteRange() ? request.byteRange : nil
-                return WebServerResourceResponse(
-                    inputStream: stream,
-                    range: range,
-                    contentType: resource.link.type ?? MediaType.binary.string
-                )
-                
-            case .failure(let error):
-                print("\(href): \(error)")
-                return GCDWebServerErrorResponse(statusCode: error.httpStatusCode)
-            }
+            let range = request.hasByteRange() ? request.byteRange : nil
+            return WebServerResourceResponse(
+                resource: resource,
+                range: range,
+                contentType: resource.link.type ?? MediaType.binary.string
+            )
         }
         
         webServer.addHandler(

--- a/r2-streamer-swift/Server/WebServerResourceResponse.swift
+++ b/r2-streamer-swift/Server/WebServerResourceResponse.swift
@@ -28,28 +28,25 @@ public enum WebServerResponseError: Error {
 /// If the ressource to be served is too big, multiple responses will be created.
 open class WebServerResourceResponse: GCDWebServerFileResponse {
 
-    // The range of data served on this response (?)
-    var range: Range<UInt64>?
-    var inputStream: SeekableInputStream
-    lazy var totalNumberOfBytesRead = UInt64(0)
-    let bufferSize = 32 * 1024
-    var buffer: Array<UInt8>
+    private let bufferSize = 32 * 1024
+
+    private var resource: Resource
+    private var range: Range<UInt64>?
+    private let length: UInt64
+    private var offset: UInt64 = 0
+    private lazy var totalNumberOfBytesRead = UInt64(0)
 
     /// Initialise the WebServerRessourceResponse object, defining what will be
     /// served.
     ///
     /// - Parameters:
-    ///   - inputStream: The data stream containing the ressource's data to
-    ///                  serve in the response.
-    ///   - range: The range of ressource's data served previously, if any.
+    ///   - resource: The publication resource to be served.
+    ///   - range: The range of resource's data served previously, if any.
     ///   - contentType: The content-type of the response's ressource.
-    public init(inputStream: SeekableInputStream, range: NSRange?, contentType: String) {
-        let streamLength = inputStream.length
+    public init(resource: Resource, range: NSRange?, contentType: String) {
+        self.resource = resource
+        self.length = (try? resource.length.get()) ?? 0
 
-        // Initialize buffer
-        buffer = Array<UInt8>(repeating: 0, count: bufferSize)
-        // Set inputStream
-        self.inputStream = inputStream
         // If range is non nil - means it's not the first part (?)
         if let range = range {
             WebServerResourceResponse.log(.debug, "Request range at \(range.location) remaining: \(range.length).")
@@ -81,9 +78,9 @@ open class WebServerResourceResponse: GCDWebServerFileResponse {
                 return newRange
             }
             self.range = getNextRange(after: range,
-                                      forStreamOfLength: streamLength)
+                forStreamOfLength: length)
         } else /* nil */ {
-            self.range = 0..<streamLength
+            self.range = 0..<length
         }
         super.init()
 
@@ -97,7 +94,7 @@ open class WebServerResourceResponse: GCDWebServerFileResponse {
         if let range = self.range {
             let lower = range.lowerBound
             let upper = (range.upperBound != 0) ? range.upperBound - 1 : range.upperBound
-            let contentRange = "bytes \(lower)-\(upper)/\(streamLength)"
+            let contentRange = "bytes \(lower)-\(upper)/\(length)"
             let acceptRange = "bytes"
 
             statusCode = 206
@@ -113,47 +110,29 @@ open class WebServerResourceResponse: GCDWebServerFileResponse {
         // TODO: setValue("", forAdditionalHeader: "Cache-Control")
     }
 
-    /// Open the inputStream and set position to the beggining of the stream.
-    ///
-    /// - Throws: `WebServerResponseError.streamOpenFailed`,
-    ///           `WebServerResponseError.invalidRange`.
     override open func open() throws {
-        inputStream.open()
-        guard inputStream.streamStatus == .open else {
-            inputStream.close()
-            throw WebServerResponseError.streamOpenFailed
-        }
-        guard let range = range else {
-            throw WebServerResponseError.invalidRange
-        }
-        try inputStream.seek(offset: Int64(range.lowerBound), whence: .startOfFile)
+        offset = range?.lowerBound ?? 0
     }
 
-    /// Read data on the inputStream, up to bufferSize bytes.
-    ///
-    /// - Returns: The data that have been read.
-    /// - Throws: `WebServerResponseError.invalidRange`.
+    /// Read a new chunk of data.
     override open func readData() throws -> Data {
         guard let range = range else {
             throw WebServerResponseError.invalidRange
         }
         let len = min(bufferSize, range.count - Int(totalNumberOfBytesRead))
         // If nothing to read, return
-        guard len > 0 else {
+        guard len > 0 && offset < length else {
             return Data()
         }
         // Read
-        let numberOfBytesRead = inputStream.read(&buffer, maxLength: len)
-        guard numberOfBytesRead > 0 else {
-            return Data()
-        }
-        totalNumberOfBytesRead += UInt64(numberOfBytesRead)
-        return Data(bytes: buffer, count: numberOfBytesRead)
+        let data = try resource.read(range: offset..<(offset + UInt64(len))).get()
+        totalNumberOfBytesRead += UInt64(data.count)
+        offset += UInt64(data.count)
+        return data
     }
 
-    /// Closes the inputStream.
     override open func close() {
-        inputStream.close()
+        resource.close()
     }
 }
 

--- a/r2-streamer-swift/Toolkit/Extensions/Fetcher.swift
+++ b/r2-streamer-swift/Toolkit/Extensions/Fetcher.swift
@@ -68,7 +68,7 @@ func makeFetcher(for url: URL) throws -> Fetcher {
     }
     
     do {
-        return try ArchiveFetcher(archive: DefaultArchiveFactory().open(url: url, password: nil))
+        return try ArchiveFetcher(archive: DefaultArchiveFactory().open(url: url, password: nil).get())
     } catch {
         return FileFetcher(href: "/\(url.lastPathComponent)", path: url)
     }

--- a/r2-streamer-swiftTests/Extensions.swift
+++ b/r2-streamer-swiftTests/Extensions.swift
@@ -10,7 +10,7 @@ import R2Shared
 extension ArchiveFetcher {
     
     convenience init(url: URL, password: String? = nil) throws {
-        try self.init(archive: DefaultArchiveFactory().open(url: url, password: password))
+        try self.init(archive: DefaultArchiveFactory().open(url: url, password: password).get())
     }
     
 }


### PR DESCRIPTION
* See https://github.com/readium/r2-shared-swift/pull/130 for the new Archive API.
* Resource is served directly instead of using the `ResourceInputStream` indirection.