### PR TITLE
Fix crash when reading obfuscated resources with an empty publication ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ All notable changes to this project will be documented in this file.
 
 * The default EPUB positions service now uses the archive entry length when available. [This is similar to how Adobe RMSDK generates page numbers](https://github.com/readium/architecture/issues/123).
     * To use the former strategy, create the `Streamer` with: `Streamer(parsers: [EPUBParser(reflowablePositionsStrategy: .originalLength(pageLength: 1024))])`
-    
+
+### Fixed
+
+* [#208](https://github.com/readium/r2-streamer-swift/issues/208) Crash when reading obfuscated EPUB resources with an empty publication identifier.
+
 
 ## [2.0.0]
 

--- a/r2-streamer-swift/Parser/EPUB/Resource Transformers/EPUBDeobfuscator.swift
+++ b/r2-streamer-swift/Parser/EPUB/Resource Transformers/EPUBDeobfuscator.swift
@@ -35,9 +35,10 @@ final class EPUBDeobfuscator {
     func deobfuscate(resource: Resource) -> Resource {
         // Checks if the resource is obfuscated with a known algorithm.
         guard
+            !publicationId.isEmpty && publicationId != "urn:uuid:",
             let algorithmId = resource.link.properties.encryption?.algorithm,
-            let algorithm = algorithms.first(withIdentifier: algorithmId) else
-        {
+            let algorithm = algorithms.first(withIdentifier: algorithmId)
+        else {
             return resource
         }
 
@@ -51,6 +52,7 @@ final class EPUBDeobfuscator {
         private let key: [UInt8]
         
         init(resource: Resource, algorithm: ObfuscationAlgorithm, key: [UInt8]) {
+            assert(key.count > 0)
             self.algorithm = algorithm
             self.key = key
             super.init(resource)

--- a/r2-streamer-swiftTests/Fixtures/EPUBDeobfuscator/nav.xhtml
+++ b/r2-streamer-swiftTests/Fixtures/EPUBDeobfuscator/nav.xhtml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+    <head>
+        <meta charset="utf-8" />
+        <link rel="stylesheet" type="text/css" href="../css/base.css" />
+		<meta name="viewport" content="width=576, height=1024"/>
+    </head>
+    <body class="reflow">
+		<nav xmlns:epub="http://www.idpf.org/2007/ops" epub:type="toc" id="toc">
+			<ol style="list-style-type: none;">
+				<li class="toc" id="chapter01">
+                	<a href="xhtml-001.xhtml">Chapter 1 - XHTML Content</a>
+               	</li>
+				<li class="toc" id="chapter02">
+                	<a href="multimedia-001.xhtml">Chapter 2 - Multimedia Content</a>
+               	</li>
+				<li class="toc" id="chapter03">
+                	<a href="spine-images-001.xhtml">Chapter 3 - Images in the Spine</a>
+               	</li>
+				<li class="toc" id="chapter04">
+                	<a href="mathml-001.xhtml">Chapter 4 - MathML</a>
+               	</li>			
+				<li class="toc" id="chapter05">
+                	<a href="svg-001.xhtml">Chapter 5 - SVG on the Page</a>
+               	</li>			
+ 				<li class="toc" id="chapter06">
+                	<a href="fallbacks-001.xhtml">Chapter 6 - Fallbacks</a>
+               	</li>			
+ 				<li class="toc" id="chapter07">
+                	<a href="fonts-xhtml-001.xhtml">Chapter 7 - Fonts</a>
+               	</li>	           
+  				<li class="toc" id="chapter08">
+                	<a href="scripting-001.xhtml">Chapter 8 - Scripting</a>
+                </li>
+  				<li class="toc" id="chapter09">
+                	<a href="media-overlays-001.xhtml">Chapter 9 - Media Overlays</a>
+                </li>
+  				<li class="toc" id="chapter10">
+                	<a href="epub-cfi-001.xhtml">Chapter 10 - Content Fragment Identifiers</a>
+                </li>
+  				<li class="toc" id="chapter11">
+                	<a href="epub-nav-001.xhtml">Chapter 11 - Navigation</a>
+                </li>
+  				<li class="toc" id="chapter12">
+                	<a href="epub-layout-001.xhtml">Chapter 12 - Layout</a>
+                </li>
+                <li class="subcategory"><span><br/>Test Links</span>
+					<ol>
+						<li><a href="epub-nav-002b.xhtml">Hamlet</a></li>
+						<li><a href="epub-nav-002b.xhtml#nav-2b">Check</a></li>
+					</ol>
+				</li>              
+             </ol>
+		</nav>
+    </body>
+</html>

--- a/r2-streamer-swiftTests/Parser/EPUB/Resource Transformers/EPUBDeobfuscatorTests.swift
+++ b/r2-streamer-swiftTests/Parser/EPUB/Resource Transformers/EPUBDeobfuscatorTests.swift
@@ -39,6 +39,20 @@ class EPUBDeobfuscatorTests: XCTestCase {
         XCTAssertEqual(result, font)
     }
 
+    // Fix for https://github.com/readium/r2-streamer-swift/issues/208
+    func testEmptyPublicationID() throws {
+        let file = fixtures.data(at: "nav.xhtml")
+        let resource = makeResource(at: "nav.xhtml", algorithm: "http://www.idpf.org/2008/embedding")
+
+        var deobfuscator = EPUBDeobfuscator(publicationId: "urn:uuid:")
+        var result = try deobfuscator.deobfuscate(resource: resource).read().get()
+        XCTAssertEqual(result, file)
+
+        deobfuscator = EPUBDeobfuscator(publicationId: "")
+        result = try deobfuscator.deobfuscate(resource: resource).read().get()
+        XCTAssertEqual(result, file)
+    }
+
     func makeResource(at path: String, algorithm: String) -> DataResource {
         let link = Link(
             href: path,


### PR DESCRIPTION
* Fix #208 